### PR TITLE
Improve example for unrecognized dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ allprojects {
 
 There are some dependencies that cannot be detected by inspecting the generated class files. In these cases, the tool will prompt you to remove a dependency, but removing it will result in a compile error. When this happens, you can add `permitUnusedDeclared` or `permitTestUnusedDeclared` to work around it.  For example:
 ```
-implementation(project(":core:core-session:))
+implementation(project(":core:core-session:"))
 // needed to avoid dependency analysis failure
 permitUnusedDeclared(project(":core:core-session"))
 ```


### PR DESCRIPTION
- To make it more clear that the original api/implementation is still needed when ignoring a failure