### PR TITLE
Change the task to be cacheable

### DIFF
--- a/src/main/kotlin/com/faire/gradle/analyze/AnalyzeDependenciesTask.kt
+++ b/src/main/kotlin/com/faire/gradle/analyze/AnalyzeDependenciesTask.kt
@@ -4,17 +4,23 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 open class DependencyAnalysisException(message: String) : GradleException(message)
 
+@CacheableTask
 open class AnalyzeDependenciesTask : DefaultTask() {
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   var mainClassesDirs: FileCollection = project.files()
 
   @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
   var testClassesDirs: FileCollection = project.files()
 
   @Input


### PR DESCRIPTION
Following instructions here
https://docs.gradle.org/current/userguide/build_cache.html

Hoping this will improve performance of running analyzeDependencies across an entire repo repeatedly