### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ allprojects {
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(16))
+    languageVersion.set(JavaLanguageVersion.of(8))
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm") version Versions.kotlin
+  kotlin("jvm") version "1.4.30"
   `kotlin-dsl`
   `java-gradle-plugin`
   id("maven-publish")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-  `kotlin-dsl`
-}
-
-repositories {
-  mavenCentral()
-}

--- a/buildSrc/src/main/kotlin/Configuration.kt
+++ b/buildSrc/src/main/kotlin/Configuration.kt
@@ -1,5 +1,0 @@
-@file:Suppress("InvalidPackageDeclaration")
-
-object Versions {
-  val kotlin = "1.4.30"
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/kotlin/com/faire/gradle/analyze/AnalyzeDependenciesPluginTest.kt
+++ b/src/test/kotlin/com/faire/gradle/analyze/AnalyzeDependenciesPluginTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
-val KOTLIN_VERSION = "1.4.30"
+val KOTLIN_VERSION = "1.5.32"
 
 val BUILDSCRIPT = """
     buildscript {
@@ -39,7 +39,7 @@ val REMOVE_PERMIT_MAIN_LINE =
 val UNNECESSARY_TEST_LINE =
   "  Test dependencies already declared by main -- remove testImplementation()/testApi() references in build.gradle.kts: "
 
-val BOILERPLATE_ERROR_LINES = 7
+val BOILERPLATE_ERROR_LINES = 8
 
 class AnalyzeDependenciesPluginTest {
   @get:Rule


### PR DESCRIPTION
There are multiple updates in this PR which, in the end, create a modern gradle plug in.

The updates are;

- Remove the use of buildSrc: buildSrc was being used for a single variable which was used in a single place, which meant adding build complexity for something which wasn't providing any de-duplication of code.
- Update to Kotlin 7.4.2: This brings a Kotlin base of 1.5, which moves the code off 1.4 which is due to be deprecated in Gradle soon
- Move the Java version to Java 8 from 16: This addresses the issue with Android based builds which are stuck on Java 11.